### PR TITLE
change clipboard.js to clipboardJS.js

### DIFF
--- a/src/Clipboard.php
+++ b/src/Clipboard.php
@@ -137,7 +137,7 @@ class Clipboard extends InputWidget
             ['class' => 'clearfix']
         );
 
-        $view->registerJs("new Clipboard('.btn-".$id."')");
+        $view->registerJs("new ClipboardJS('.btn-".$id."')");
 
         return $content;
     }

--- a/src/ClipboardAsset.php
+++ b/src/ClipboardAsset.php
@@ -11,6 +11,6 @@ class ClipboardAsset extends BootstrapAsset
 {
     public $sourcePath = '@bower/clipboard/dist';
     public $js = [
-        'clipboard.min.js',
+        'clipboardJS.min.js',
     ];
 }


### PR DESCRIPTION
This fixes #1 
clipboard.js was updated to to clipboardJS.js to avoid a name conflict on Chrome 61+.
See https://github.com/zenorocha/clipboard.js/issues/468